### PR TITLE
Fix scroll area height on stack page

### DIFF
--- a/app/dashboard/stack/[id]/page.tsx
+++ b/app/dashboard/stack/[id]/page.tsx
@@ -38,9 +38,20 @@ export default async function StackPage({ params }: { params: { id: string } }) 
     if (!stack) return notFound();
 
     return (
-        <div className="flex flex-col overflow-hidden text-white bg-zinc-950">
-            {/* Header */}
-            <div className="shrink-0 border-b border-zinc-800 px-4 py-4 flex items-center justify-between gap-3">
+        <div className="h-full flex overflow-hidden text-white bg-zinc-950">
+            <aside className="w-64 shrink-0 border-r border-zinc-800 p-4 overflow-y-auto">
+                <h2 className="text-lg font-bold mb-2">About this stack</h2>
+                {stack.description ? (
+                    <p className="text-zinc-300">{stack.description}</p>
+                ) : (
+                    <p className="text-zinc-500 italic">No description</p>
+                )}
+                <p className="text-zinc-400 mt-4">Questions: {stack.questions.length}</p>
+            </aside>
+
+            <div className="flex flex-col flex-1 overflow-hidden">
+                {/* Header */}
+                <div className="shrink-0 border-b border-zinc-800 px-4 py-4 flex items-center justify-between gap-3">
                 {/* Back Link */}
                 <Link
                     href="/dashboard"
@@ -109,33 +120,34 @@ export default async function StackPage({ params }: { params: { id: string } }) 
                         <QuestionForm updateAction={addQuestion.bind(null, stack.id)} />
                     </DialogContent>
                 </Dialog>
-            </div>
+                </div>
 
-            {/* Scrollable Questions area */}
-            <div className="flex-1 overflow-y-auto">
-                <div className="px-4 py-6 flex flex-wrap gap-4 justify-center">
-                    {stack.questions.map((q) => (
-                        <div
-                            key={q.id}
-                            className="flex-1 min-w-[250px] max-w-sm grow sm:basis-[45%] md:basis-[30%] lg:basis-[22%]"
-                        >
-                            <Card className="bg-zinc-900 border border-zinc-800 h-full">
-                                <CardContent className="p-4">
-                                    <QuestionForm
-                                        updateAction={updateQuestion.bind(null, q.id)}
-                                        deleteAction={deleteQuestion.bind(null, q.id)}
-                                        defaultValues={{
-                                            content: q.content,
-                                            type: q.type,
-                                            choices: q.choices,
-                                            minValue: q.minValue ?? undefined,
-                                            maxValue: q.maxValue ?? undefined,
-                                        }}
-                                    />
-                                </CardContent>
-                            </Card>
-                        </div>
-                    ))}
+                {/* Scrollable Questions area */}
+                <div className="flex-1 overflow-y-auto">
+                    <div className="px-4 py-6 flex flex-wrap gap-4 justify-center">
+                        {stack.questions.map((q) => (
+                            <div
+                                key={q.id}
+                                className="flex-1 min-w-[250px] max-w-sm grow sm:basis-[45%] md:basis-[30%] lg:basis-[22%]"
+                            >
+                                <Card className="bg-zinc-900 border border-zinc-800 h-full">
+                                    <CardContent className="p-4">
+                                        <QuestionForm
+                                            updateAction={updateQuestion.bind(null, q.id)}
+                                            deleteAction={deleteQuestion.bind(null, q.id)}
+                                            defaultValues={{
+                                                content: q.content,
+                                                type: q.type,
+                                                choices: q.choices,
+                                                minValue: q.minValue ?? undefined,
+                                                maxValue: q.maxValue ?? undefined,
+                                            }}
+                                        />
+                                    </CardContent>
+                                </Card>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({
       <body
         className={`bg-zinc-950 text-zinc-100 ${geistSans.variable} ${geistMono.variable}`}
       >
-        <div className="flex flex-col h-screen w-screen">
+        <div className="flex flex-col h-screen w-screen overflow-hidden">
           <header className="flex items-center justify-between px-4 h-14 border-b border-zinc-800 bg-zinc-900">
             <div />
             <Link href="/" className="text-lg font-bold text-white">
@@ -40,7 +40,7 @@ export default async function RootLayout({
             <HeaderUserMenu />
           </header>
 
-          <main className="flex-1">
+          <main className="flex-1 overflow-hidden">
             {!isDbHealthy ? (
               <div className="flex items-center justify-center h-full">
                 <h1 className="text-2xl text-zinc-300">🚧 Maintenance</h1>


### PR DESCRIPTION
## Summary
- keep body from scrolling by preventing overflow in layout
- add a sidebar with stack stats alongside the questions list

## Testing
- `npm run lint` *(fails: many lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68660e22509c83238a0d038aa62d9115